### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/JAS0N-SMITH/cv/security/code-scanning/1](https://github.com/JAS0N-SMITH/cv/security/code-scanning/1)

To fix this issue, add an explicit `permissions` key to the workflow, granting only the minimum permissions required for the job. The peaceiris/actions-gh-pages action requires `contents: write` to push changes to the `gh-pages` branch. No other permissions are needed for this workflow as shown. The most appropriate place to add the block is at the job level (inside `build-and-deploy:`) to scope permissions just for this job, though adding at the root is also acceptable. Here, since there is only one job, either choice is functionally equivalent, but job-level is slightly preferable for future extensibility. Edit .github/workflows/deploy.yml by adding:

```yaml
permissions:
  contents: write
```
just before `runs-on: ubuntu-latest` under the `build-and-deploy:` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
